### PR TITLE
ci/release: Windows 构建 + electron-updater 自动更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+    tags-ignore: ['v*']
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build Windows package
+        if: runner.os == 'Windows'
+        run: pnpm build:win
+
+      - name: Upload Windows artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: prism-windows-${{ github.sha }}
+          path: |
+            dist/*.exe
+            dist/*.yml
+            dist/*.blockmap
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build & publish Windows release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm release:win

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Prism 桌面客户端。把视频折射成文字、大纲、文章与播客。
 
 桌面端的存在价值：
+
 - **本地网络**：yt-dlp 跑在用户机器上，不用服务器代理
 - **本地存储**：视频、音频、转录文件不经过中转
 
@@ -24,6 +25,36 @@ pnpm dev
 ```bash
 pnpm build:linux   # / :mac / :win
 ```
+
+## 发布流程
+
+本仓库使用 GitHub Actions + electron-builder 自动发版，客户端集成了
+electron-updater，用户侧可自动升级。
+
+发布新版本：
+
+```bash
+# 1. 在 package.json 升版本号（手动改 version 或 pnpm version）
+# 2. 打 tag 并推送
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+推送 `v*` tag 会触发 `.github/workflows/release.yml`：
+
+- 在 `windows-latest` 上 `pnpm install && pnpm release:win`
+- electron-builder 把 NSIS 安装包和 `latest.yml` 上传到对应 tag 的
+  GitHub Release
+
+客户端启动后调用 `setupAutoUpdater()`：
+
+- 启动时立即向 `https://github.com/xbghc/prism-desktop/releases/latest`
+  查询 `latest.yml`
+- 发现新版后自动下载，下次退出时安装
+- 运行中每 6 小时轮询一次
+
+本地开发环境（未打包）会读取 `dev-app-update.yml` 作为 feed 配置，因此开发
+模式下也能走一次更新检查的链路。
 
 ## 相关仓库
 

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,0 +1,4 @@
+provider: github
+owner: xbghc
+repo: prism-desktop
+updaterCacheDirName: prism-desktop-updater

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,3 +26,8 @@ nsis:
   allowToChangeInstallationDirectory: true
   perMachine: false
 npmRebuild: false
+publish:
+  provider: github
+  owner: xbghc
+  repo: prism-desktop
+  releaseType: release

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "npm run build && electron-builder --win"
+    "build:win": "npm run build && electron-builder --win --publish never",
+    "release:win": "npm run build && electron-builder --win --publish always"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
-    "@electron-toolkit/utils": "^4.0.0"
+    "@electron-toolkit/utils": "^4.0.0",
+    "electron-updater": "^6.8.3"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.9)
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
     devDependencies:
       '@electron-toolkit/eslint-config-prettier':
         specifier: 3.0.0
@@ -1230,6 +1233,9 @@ packages:
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
+
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1701,6 +1707,13 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2084,6 +2097,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -3464,6 +3480,19 @@ snapshots:
 
   electron-to-chromium@1.5.344: {}
 
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@5.0.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
@@ -4016,6 +4045,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
@@ -4397,6 +4430,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinyglobby@0.2.16:
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import { registerIpcHandlers } from './ipc'
 import { loadSettings } from './settings'
 import { getPaths } from './paths'
 import { createLogger } from './logger'
+import { setupAutoUpdater } from './updater'
 
 const log = createLogger('main')
 
@@ -56,6 +57,8 @@ app.whenReady().then(() => {
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+
+  setupAutoUpdater()
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,0 +1,22 @@
+import { autoUpdater } from 'electron-updater'
+import { createLogger } from './logger'
+
+const log = createLogger('updater')
+
+export function setupAutoUpdater(): void {
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.on('update-available', (info) => log.info('发现更新', info))
+  autoUpdater.on('update-downloaded', (info) => log.info('更新已下载', info))
+  autoUpdater.on('error', (err) => log.error('更新失败', { err: String(err) }))
+  void autoUpdater
+    .checkForUpdatesAndNotify()
+    .catch((err) => log.warn('检查更新异常', { err: String(err) }))
+  setInterval(
+    () =>
+      void autoUpdater
+        .checkForUpdatesAndNotify()
+        .catch((err) => log.warn('定时检查失败', { err: String(err) })),
+    6 * 3600 * 1000
+  )
+}


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/ci.yml`：push/PR 触发，matrix `ubuntu-latest` 和 `windows-latest`，两端跑 typecheck + lint，Windows 端额外 `pnpm build:win` 并上传 NSIS 安装包 artifact（Node 22 + pnpm 10 缓存）
- 新增 `.github/workflows/release.yml`：`v*` tag 触发，在 `windows-latest` 上 `pnpm install && pnpm release:win`，electron-builder 直接 publish 到 GitHub Release（用 `GITHUB_TOKEN`）
- `electron-builder.yml` 加 `publish: github` 指向 `xbghc/prism-desktop`
- 新增 `dev-app-update.yml`（开发环境 feed 配置）
- `package.json` scripts 拆分 `build:win`（`--publish never`）和 `release:win`（`--publish always`），加 `electron-updater` 依赖
- 新增 `src/main/updater.ts`：`setupAutoUpdater()` 启用自动下载 + 退出时安装，监听 update-available/downloaded/error，启动时查一次、之后每 6 小时轮询
- `src/main/index.ts`：仅在 `app.whenReady().then()` 末尾追加 `setupAutoUpdater()` 与 `import`
- README 追加「发布流程」段

## Test plan

- [x] `pnpm typecheck` 全过
- [x] 新增文件 `pnpm lint`、`pnpm format --check` 通过（pre-existing 错误在其他 worker 负责的 service/preload/shared 文件里，本 PR 未触碰）
- [x] 四份 YAML（两个 workflow + `electron-builder.yml` + `dev-app-update.yml`）语法合法
- [ ] 在 GitHub Actions 上跑一次 CI（push 后看绿灯）
- [ ] 推一个 `v*` tag 验证 release 工作流实际发布到 GitHub Release

## 对其他 worker 的影响

- `src/main/index.ts` 末尾 append 一行 `setupAutoUpdater()` 并加一条 import（契约允许的改动范围）
- 其他所有受限文件（`src/shared/**`、`src/preload/**`、`src/main/ipc/**`、`pipeline.ts`、`services/**`、`settings.ts`、`workspace-store.ts`、`events.ts`、`paths.ts`、`logger.ts`、`src/renderer/**`、`src/main/platform/**`）未修改

🤖 Generated with [Claude Code](https://claude.com/claude-code)